### PR TITLE
Update missed bazelBootstrap hashes

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix
@@ -108,23 +108,23 @@ let
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel_nojdk-${version}-linux-x86_64";
-          hash = "sha256-CYL1paAtzTbfl7TfsqwJry/dkoTO/yZdHrX0NSA1+Ig=";
+          hash = "sha256-94KFvsS7fInXFTQZPzMq6DxnHQrRktljwACyAz8adSw=";
         }
       else if stdenv.hostPlatform.system == "aarch64-linux" then
         fetchurl {
           url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel_nojdk-${version}-linux-arm64";
-          hash = "sha256-6DzTEx218/Qq38eMWvXOX/t9VJDyPczz6Edh4eHdOfg=";
+          hash = "sha256-wfuZLSHa77wr0A4ZLF5DqH7qyOljYNXM2a5imoS+nGQ";
         }
       else if stdenv.hostPlatform.system == "x86_64-darwin" then
         fetchurl {
           url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-darwin-x86_64";
-          hash = "sha256-Ut00wXzJezqlvf49RcTjk4Im8j3Qv7R77t1iWpU/HwU=";
+          hash = "sha256-qAb9s6R5+EbqVfWHUT7sk1sOrbDEPv4EhgXH7nC46Zw=";
         }
       else
         fetchurl {
           # stdenv.hostPlatform.system == "aarch64-darwin"
           url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-darwin-arm64";
-          hash = "sha256-ArEXuX0JIa5NT04R0n4sCTA4HfQW43NDXV0EGcaibyQ=";
+          hash = "sha256-4bRp4OvkRIvhpZ2r/eFJdwrByECHy3rncDEM1tClFYo=";
         };
 
     nativeBuildInputs = defaultShellUtils;


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/2854768f67f4c914d99d3bd214daeb00dfd8d0fd changed the version but failed to update the hashes of these downloads for the _new_ version of Bazel being referenced, yielding build failures if anyone had to rely on this bootstrapping process

Given this slipped by for several months, I'm not 100% sure if anything automated is going to catch is, so here's a POC Nix flake
```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    flake-utils.url = "github:numtide/flake-utils";
  };
  outputs =
    {
      self,
      nixpkgs,
      flake-utils,
    }:
    flake-utils.lib.eachDefaultSystem (
      system:
      let
        pkgs = nixpkgs.legacyPackages.${system};
        version = builtins.getEnv "VERSION";
        x86 = pkgs.fetchurl {
          url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel_nojdk-${version}-linux-x86_64";
          hash = "sha256-CYL1paAtzTbfl7TfsqwJry/dkoTO/yZdHrX0NSA1+Ig=";
        };
        aarch = pkgs.fetchurl {
          url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel_nojdk-${version}-linux-arm64";
          hash = "sha256-6DzTEx218/Qq38eMWvXOX/t9VJDyPczz6Edh4eHdOfg=";
        };
        x86-darwin = pkgs.fetchurl {
          url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-darwin-x86_64";
          hash = "sha256-Ut00wXzJezqlvf49RcTjk4Im8j3Qv7R77t1iWpU/HwU=";
        };
        aarch-darwin = pkgs.fetchurl {
          url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-darwin-arm64";
          hash = "sha256-ArEXuX0JIa5NT04R0n4sCTA4HfQW43NDXV0EGcaibyQ=";
        };
      in
      {
        packages = {
          x86 = x86;
          aarch = aarch;
          x86-darwin = x86-darwin;
          aarch-darwin = aarch-darwin;
        };
      }
    );
}
```
```sh
❯ for ver in "7.6.0" "7.4.1"
      for arch in ".#x86" ".#x86-darwin" ".#aarch" ".#aarch-darwin"
          VERSION=$ver nix build $arch --impure
      end
      echo $ver
  end
error: hash mismatch in fixed-output derivation '/nix/store/bh2f614a7czcy4iwj97ss73qfyy0z7sl-bazel_nojdk-7.6.0-linux-x86_64.drv':
           likely URL: https://github.com/bazelbuild/bazel/releases/download/7.6.0/bazel_nojdk-7.6.0-linux-x86_64
            specified: sha256-CYL1paAtzTbfl7TfsqwJry/dkoTO/yZdHrX0NSA1+Ig=
                  got: sha256-94KFvsS7fInXFTQZPzMq6DxnHQrRktljwACyAz8adSw=
        expected path: /nix/store/z53mxsp115kh7kkikv5krw89456a3vc7-bazel_nojdk-7.6.0-linux-x86_64
             got path: /nix/store/8cz0nic3i32wpgv8ydl5x6nh7d4nlp6i-bazel_nojdk-7.6.0-linux-x86_64
error: hash mismatch in fixed-output derivation '/nix/store/s8cnfq598c38skkhy4m7k9h82733g70k-bazel-7.6.0-darwin-x86_64.drv':
           likely URL: https://github.com/bazelbuild/bazel/releases/download/7.6.0/bazel-7.6.0-darwin-x86_64
            specified: sha256-Ut00wXzJezqlvf49RcTjk4Im8j3Qv7R77t1iWpU/HwU=
                  got: sha256-qAb9s6R5+EbqVfWHUT7sk1sOrbDEPv4EhgXH7nC46Zw=
        expected path: /nix/store/dgi8g6y254b97ji07y8pk0lgbbn0l6in-bazel-7.6.0-darwin-x86_64
             got path: /nix/store/qb08s1hs6x5b6fxcs531b4sx08lw1lnn-bazel-7.6.0-darwin-x86_64
error: hash mismatch in fixed-output derivation '/nix/store/vgvvq5rzrnbziplgfcjqilaxmykcl0x8-bazel_nojdk-7.6.0-linux-arm64.drv':
           likely URL: https://github.com/bazelbuild/bazel/releases/download/7.6.0/bazel_nojdk-7.6.0-linux-arm64
            specified: sha256-6DzTEx218/Qq38eMWvXOX/t9VJDyPczz6Edh4eHdOfg=
                  got: sha256-wfuZLSHa77wr0A4ZLF5DqH7qyOljYNXM2a5imoS+nGQ=
        expected path: /nix/store/fjhrspa0j5xrxd48805prhcx0519bjxj-bazel_nojdk-7.6.0-linux-arm64
             got path: /nix/store/g3cr9kgdrmx3kpqn02s7ky3k582bq7p6-bazel_nojdk-7.6.0-linux-arm64
error: hash mismatch in fixed-output derivation '/nix/store/ccsz3rna9zy9ilql1hz0j1rmpm0yvcsc-bazel-7.6.0-darwin-arm64.drv':
           likely URL: https://github.com/bazelbuild/bazel/releases/download/7.6.0/bazel-7.6.0-darwin-arm64
            specified: sha256-ArEXuX0JIa5NT04R0n4sCTA4HfQW43NDXV0EGcaibyQ=
                  got: sha256-4bRp4OvkRIvhpZ2r/eFJdwrByECHy3rncDEM1tClFYo=
        expected path: /nix/store/gsgk7mv6qdkqkzxdfg459w299blafygq-bazel-7.6.0-darwin-arm64
             got path: /nix/store/gzacgksh2s1lnm9yfn2ir949rkvbrma6-bazel-7.6.0-darwin-arm64
7.6.0
7.4.1
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
